### PR TITLE
Larvel documentation: Changed config value naming

### DIFF
--- a/docs/integrations/php/laravel.md
+++ b/docs/integrations/php/laravel.md
@@ -33,7 +33,7 @@ class AppServiceProvider extends ServiceProvider
                 new Dsn(
                     'ohmysmtp+api',
                     'default',
-                    config('services.ohmysmtp.key')
+                    config('services.mailpace.key')
                 )
             );
         });


### PR DESCRIPTION
I was trying this out and realized that the config values in the documentation do not match.